### PR TITLE
Fixing schema blank WS request

### DIFF
--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -122,8 +122,16 @@ class CombinationCore extends ObjectModel
             'id_product' => ['required' => true, 'xlink_resource' => 'products'],
         ],
         'associations' => [
-            'product_option_values' => ['resource' => 'product_option_value'],
-            'images' => ['resource' => 'image', 'api' => 'images/products'],
+            'product_option_values' => [
+                'resource' => 'product_option_value',
+                'fields' => [
+                    'id' => ['required' => true],
+                ],
+            ],
+            'images' => [
+                'resource' => 'image',
+                'fields' => ['id' => []],
+            ],
         ],
     ];
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x / 8.0.x  since PS 8 version
| Description?      | Requesting schema blank on Webservice Combinations it will produce an error "StartTag: invalid element name" and the schema is not rendered correctly because of the presence of "<0>" tags in the XML.
| Type?             | bug fix
| Category?         |WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try to get a schema blank for the Combination: https://yourdomain.com/api/combinations/?1&schema=blank&ws_key=yourwebservicekey
| Sponsor company   | Simone - UnusualDope
